### PR TITLE
Add after_stop asserts for messaging tests

### DIFF
--- a/acton-reactive/examples/broadcast/main.rs
+++ b/acton-reactive/examples/broadcast/main.rs
@@ -13,7 +13,7 @@
  * See the applicable License for the specific language governing permissions and
  * limitations under that License.
  */
-use std::io::{stdout, Write};
+use std::io::stdout;
 use std::io::Stdout;
 
 use crossterm::{

--- a/acton-reactive/examples/fruit_market/main.rs
+++ b/acton-reactive/examples/fruit_market/main.rs
@@ -57,13 +57,6 @@ const LOG_FILENAME: &str = "fruit_market.log"; // Base name for log files.
 #[derive(Clone, Debug)]
 struct ItemScanned(CartItem);
 
-/// Message sent to finalize the transaction, possibly containing the total price.
-#[derive(Clone, Debug)]
-struct FinalizeSale(Price);
-
-/// Message sent to request the current list of items from the register/cart.
-#[derive(Clone, Debug)]
-struct GetItems;
 
 /// Message sent to request the price of a specific item.
 #[derive(Clone, Debug)]

--- a/acton-reactive/examples/fruit_market/price_service.rs
+++ b/acton-reactive/examples/fruit_market/price_service.rs
@@ -86,6 +86,6 @@ impl PriceService {
         // Simulate network/database latency.
         tokio::time::sleep(Duration::from_millis(MOCK_DELAY_MS)).await;
         // Generate a random price within the defined range (in cents).
-        rand::thread_rng().gen_range(PRICE_MIN..=PRICE_MAX)
+        rand::rng().random_range(PRICE_MIN..=PRICE_MAX)
     }
 }

--- a/acton-reactive/examples/fruit_market/printer.rs
+++ b/acton-reactive/examples/fruit_market/printer.rs
@@ -38,7 +38,6 @@ use crate::cart_item::CartItem;
 // --- Constants for UI Layout and Styling ---
 const COLS: u16 = 40; // Width of the receipt area
 const PAD_LEFT: u16 = 3; // Left padding for the receipt
-const MARGIN_TOP: u16 = 1; // Top margin (unused currently)
 const PAD_TOP: u16 = 2; // Top padding for the receipt content
 const HEADER_HEIGHT: u16 = 4; // Height reserved for the header section
 const TRANSACTION_RECEIPT: &str = "Transaction Receipt"; // Header title

--- a/acton-reactive/examples/fruit_market/register.rs
+++ b/acton-reactive/examples/fruit_market/register.rs
@@ -14,9 +14,8 @@
  * limitations under that License.
  */
 
-
-use rand::seq::IndexedMutRandom;
 use rand::prelude::*;
+
 use tracing::trace;
 
 use acton_core::prelude::*;

--- a/acton-reactive/tests/actor_tests.rs
+++ b/acton-reactive/tests/actor_tests.rs
@@ -14,6 +14,8 @@
  * limitations under that License.
  */
 
+#![allow(dead_code, unused_doc_comments)]
+
 use tracing::{info, trace};
 
 use acton_reactive::prelude::*;

--- a/acton-reactive/tests/broker_tests.rs
+++ b/acton-reactive/tests/broker_tests.rs
@@ -14,6 +14,8 @@
  * limitations under that License.
  */
 
+#![allow(dead_code, unused_doc_comments)]
+
 use tracing::*;
 
 use acton_reactive::prelude::*;

--- a/acton-reactive/tests/direct_messaging_tests.rs
+++ b/acton-reactive/tests/direct_messaging_tests.rs
@@ -14,6 +14,8 @@
  * limitations under that License.
  */
 
+#![allow(dead_code, unused_doc_comments)]
+
 use tracing::{info, instrument, trace};
 
 use acton_reactive::prelude::*;

--- a/acton-reactive/tests/launchpad_tests.rs
+++ b/acton-reactive/tests/launchpad_tests.rs
@@ -14,6 +14,8 @@
  * limitations under that License.
  */
 
+#![allow(dead_code, unused_doc_comments)]
+
 use std::time::Duration;
 
 use tracing::*;

--- a/acton-reactive/tests/lifecycle_tests.rs
+++ b/acton-reactive/tests/lifecycle_tests.rs
@@ -13,6 +13,8 @@
  * See the applicable License for the specific language governing permissions and
  * limitations under that License.
  */
+#![allow(dead_code, unused_doc_comments)]
+
 use acton_reactive::prelude::*;
 use acton_test::prelude::*;
 

--- a/acton-reactive/tests/messaging_tests.rs
+++ b/acton-reactive/tests/messaging_tests.rs
@@ -14,6 +14,8 @@
  * limitations under that License.
  */
 
+#![allow(dead_code, unused_doc_comments)]
+
 use tracing::*;
 
 use acton_reactive::prelude::*;
@@ -62,6 +64,7 @@ async fn test_messaging_behavior() -> anyhow::Result<()> {
         })
         // Handler executed after the agent stops.
         .after_stop(|agent| {
+            assert_eq!(agent.model.receive_count, 1, "expected one Ping");
             info!("Processed {} Pings", agent.model.receive_count);
             // Implicitly verifies count is 1 based on the log message.
             AgentReply::immediate()
@@ -150,6 +153,7 @@ async fn test_async_messaging_behavior() -> anyhow::Result<()> {
             AgentReply::immediate()
         })
         .after_stop(|agent| {
+            assert_eq!(agent.model.receive_count, 1, "expected one Ping");
             info!("Processed {} Pings", agent.model.receive_count);
             // Implicitly verifies count is 1.
             AgentReply::immediate()


### PR DESCRIPTION
## Summary
- ensure ping receive count is explicitly asserted in messaging tests
- silence clippy warnings in tests and examples

## Testing
- `cargo check -p acton-reactive --quiet`
- `cargo test -p acton-reactive --quiet`
- `cargo clippy -p acton-reactive --tests --quiet -- -D warnings`
