### PR TITLE
fix: compile on non-Unix targets by resolving config paths per platform

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,3 +24,16 @@ jobs:
       run: cargo test --verbose --features ipc-messagepack
     - name: Run tests (no default features)
       run: cargo test --verbose -p acton-reactive --no-default-features
+
+  windows:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Check no default features
+      run: cargo check --verbose -p acton-reactive --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -696,7 +696,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -906,7 +906,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1049,7 +1049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1090,7 +1090,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "acton-macro"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "acton-reactive"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "acton-ern",
  "acton-macro",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "acton_test"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "acton_test_macro",
  "parking_lot",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "acton_test_macro"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "parking_lot",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ repository = "https://github.com/Govcraft/acton-reactive"
 [workspace.dependencies]
 # Internal crates
 acton-macro = { path = "acton-macro", version = "9.1.0" }
-acton-reactive = { path = "acton-reactive", version = "9.1.0" }
 acton_test = { path = "acton-test", version = "9.1.0" }
 acton_test_macro = { path = "acton-test-macro", version = "9.1.0" }
 
@@ -51,7 +50,6 @@ acton-ern = "2"
 static_assertions = "1.1.0"
 dyn-clone = "1.0.17"
 derive-new = "0.7.0"
-xdg = "2.5"
 rand = "0.9.1"
 
 # Dev/test dependencies
@@ -60,11 +58,6 @@ mti = "1.0.0"
 zerocopy = "0.8.24"
 ansi_term = "0.12.1"
 tempfile = "3.10.0"
-
-# CLI dependencies
-miette = { version = "7.2.0", features = ["fancy"] }
-thiserror = "1.0.64"
-handlebars = "6.1.0"
 
 # Shared lints
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["acton-macro", "acton-test", "acton-reactive", "acton-test-macro"]
 
 # Shared package metadata
 [workspace.package]
-version = "9.1.0"
+version = "9.2.0"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/Govcraft/acton-reactive"
@@ -14,9 +14,10 @@ repository = "https://github.com/Govcraft/acton-reactive"
 # Centralized dependencies
 [workspace.dependencies]
 # Internal crates
-acton-macro = { path = "acton-macro", version = "9.1.0" }
-acton_test = { path = "acton-test", version = "9.1.0" }
-acton_test_macro = { path = "acton-test-macro", version = "9.1.0" }
+acton-macro = { path = "acton-macro", version = "9.2.0" }
+acton-reactive = { path = "acton-reactive", version = "9.2.0" }
+acton_test = { path = "acton-test", version = "9.2.0" }
+acton_test_macro = { path = "acton-test-macro", version = "9.2.0" }
 
 # Async runtime
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "time", "macros"] }

--- a/acton-docs-site/src/lib/version.ts
+++ b/acton-docs-site/src/lib/version.ts
@@ -2,4 +2,4 @@
  * Version information for acton-reactive
  * This should match the version in the root Cargo.toml workspace.package.version
  */
-export const VERSION = '9.1.0'
+export const VERSION = '9.2.0'

--- a/acton-docs-site/src/markdoc/config.js
+++ b/acton-docs-site/src/markdoc/config.js
@@ -4,7 +4,7 @@ import { siteConfig } from '../lib/config'
 
 // Extract version from workspace Cargo.toml
 // This should be kept in sync with the workspace version
-const ACTON_VERSION = '9.1.0'
+const ACTON_VERSION = '9.2.0'
 
 // Helper function to build dependency string
 function buildDep(features) {

--- a/acton-reactive/CHANGELOG.md
+++ b/acton-reactive/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to `acton-reactive` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.2.0] - 2026-08-19
+
+Makes the crate compile off Unix. Nothing behaves differently on Unix.
+
+### Fixed
+
+- **The crate no longer fails to build on non-Unix targets.** `xdg` is declared
+  under `[target.'cfg(unix)'.dependencies]`, but `ActonConfig::load` named it
+  unconditionally, so `cargo check --target x86_64-pc-windows-msvc` died with
+  `cannot find module or crate xdg` before reaching any Acton code. Configuration
+  discovery now goes through a single internal module that states the platform
+  rule once: the XDG search path under the `acton` prefix on Unix, and
+  `%APPDATA%\acton\config.toml` everywhere else.
+
+  Unix resolution is unchanged, including `$XDG_CONFIG_HOME` and the
+  `$XDG_CONFIG_DIRS` search path. A configuration directory that cannot be
+  determined at all is now distinguished from one that simply holds no file, so
+  the former is logged as an error rather than passed off as "using defaults".
+
+### Changed
+
+- **Enabling `ipc` on a non-Unix target now fails with an explanation.** The
+  feature is built on Unix domain sockets and never could have worked there; it
+  previously produced a wall of unresolved-import errors from the transport
+  layer. A `compile_error!` now leads that output and names the fix.
+
 ## [9.1.0] - 2026-08-12
 
 Adds scheduled sends. Nothing existing behaves differently.

--- a/acton-reactive/Cargo.toml
+++ b/acton-reactive/Cargo.toml
@@ -22,7 +22,6 @@ dyn-clone.workspace = true
 derive-new.workspace = true
 acton-ern.workspace = true
 tracing-appender.workspace = true
-xdg.workspace = true
 serde.workspace = true
 toml.workspace = true
 rand.workspace = true
@@ -178,3 +177,6 @@ required-features = ["ipc"]
 [[bench]]
 name = "actor_benchmarks"
 harness = false
+
+[target."cfg(unix)".dependencies]
+xdg = "2.5"

--- a/acton-reactive/src/common/config.rs
+++ b/acton-reactive/src/common/config.rs
@@ -15,13 +15,15 @@
  */
 
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::sync::LazyLock;
 use std::time::Duration;
 
 /// Configuration for the Acton Reactive framework
 ///
-/// This struct contains all configurable values for the Acton framework,
-/// loaded from TOML files in XDG-compliant directories.
+/// This struct contains all configurable values for the Acton framework, loaded
+/// from a TOML file in the host platform's configuration directory (XDG on Unix,
+/// `%APPDATA%` elsewhere). See [`ActonConfig::load`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 #[derive(Default)]
@@ -169,31 +171,27 @@ impl ActonConfig {
         Duration::from_millis(self.timeouts.system_shutdown)
     }
 
-    /// Load configuration from XDG-compliant locations
+    /// Load configuration from the host platform's configuration directory
     ///
-    /// This function attempts to load configuration from the following locations
-    /// in order of preference:
-    /// 1. `$XDG_CONFIG_HOME/acton/config.toml` (Linux/macOS)
-    /// 2. `~/.config/acton/config.toml` (Linux fallback)
-    /// 3. `~/Library/Application Support/acton/config.toml` (macOS fallback)
-    /// 4. `%APPDATA%/acton/config.toml` (Windows)
+    /// On Unix the XDG base directory search path is used, under the `acton`
+    /// prefix: `$XDG_CONFIG_HOME/acton/config.toml` (defaulting to
+    /// `~/.config/acton/config.toml`), then each entry of `$XDG_CONFIG_DIRS`.
+    /// On every other platform the file is read from `%APPDATA%\acton\config.toml`.
     ///
     /// If no configuration file is found, returns the default configuration.
     /// If a configuration file exists but is malformed, logs an error and uses defaults.
     pub fn load() -> Self {
         use tracing::{error, info};
 
-        // Get the XDG base directories
-        let xdg_dirs = match xdg::BaseDirectories::with_prefix("acton") {
-            Ok(dirs) => dirs,
+        let located = match super::config_paths::find_config_file(Path::new("config.toml")) {
+            Ok(located) => located,
             Err(e) => {
-                error!("Failed to initialize XDG directories: {}", e);
+                error!("Failed to locate the configuration directory: {}", e);
                 return Self::default();
             }
         };
 
-        // Try to find the configuration file
-        xdg_dirs.find_config_file("config.toml").map_or_else(
+        located.map_or_else(
             || {
                 info!("No configuration file found, using defaults");
                 Self::default()
@@ -229,5 +227,6 @@ impl ActonConfig {
     }
 }
 
-/// Global configuration instance loaded from XDG-compliant locations
+/// Global configuration instance loaded from the host platform's configuration
+/// directory
 pub static CONFIG: LazyLock<ActonConfig> = LazyLock::new(ActonConfig::load);

--- a/acton-reactive/src/common/config_paths.rs
+++ b/acton-reactive/src/common/config_paths.rs
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2024. Govcraft
+ *
+ * Licensed under either of
+ *   * Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     you may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *   * MIT license: http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the applicable License for the specific language governing permissions and
+ * limitations under that License.
+ */
+
+//! Platform-specific discovery of Acton's configuration files.
+//!
+//! Every part of the crate that needs to know *where* configuration lives goes
+//! through [`find_config_file`], so the platform difference is stated once:
+//!
+//! * **Unix** — the XDG base directory search path, under the `acton` prefix.
+//!   `$XDG_CONFIG_HOME/acton/<relative>` first, then each entry of
+//!   `$XDG_CONFIG_DIRS`.
+//! * **Everything else** — `%APPDATA%\acton\<relative>`.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Directory name Acton's configuration lives under, on every platform.
+const PREFIX: &str = "acton";
+
+/// Why a configuration directory could not be located.
+///
+/// This is distinct from "no configuration file exists": that is reported as
+/// `Ok(None)` by [`find_config_file`]. An error here means the search could not
+/// be performed at all, which is worth logging more loudly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigLocationError {
+    /// The XDG base directory lookup failed (Unix targets).
+    ///
+    /// Carries the underlying cause rendered as text, because the `xdg` crate's
+    /// error type is not in the dependency graph on non-Unix targets.
+    #[cfg(any(unix, test))]
+    BaseDirectories(String),
+
+    /// `%APPDATA%` is unset or empty (non-Unix targets).
+    #[cfg(any(not(unix), test))]
+    AppDataUnset,
+}
+
+impl fmt::Display for ConfigLocationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            #[cfg(any(unix, test))]
+            Self::BaseDirectories(cause) => write!(
+                f,
+                "could not determine the XDG configuration directories: {cause}; \
+                 set HOME or XDG_CONFIG_HOME to a readable directory"
+            ),
+            #[cfg(any(not(unix), test))]
+            Self::AppDataUnset => f.write_str(
+                "the APPDATA environment variable is unset or empty, so there is no \
+                 configuration directory to search; set APPDATA to the roaming \
+                 application data directory",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConfigLocationError {}
+
+/// Build the path a configuration file would occupy under an application data root.
+///
+/// Pure: it performs no I/O and consults no environment, so the layout rule can be
+/// asserted on any platform.
+#[cfg(any(not(unix), test))]
+fn app_data_config_path(app_data_root: &Path, relative: &Path) -> PathBuf {
+    app_data_root.join(PREFIX).join(relative)
+}
+
+/// Look for `relative` beneath an application data root, returning it only if it
+/// is a readable file.
+///
+/// The root is a parameter rather than an environment read so that the rule is
+/// exercised by tests on every platform, not only the one that ships it.
+#[cfg(any(not(unix), test))]
+fn find_in_app_data(app_data_root: &Path, relative: &Path) -> Option<PathBuf> {
+    let candidate = app_data_config_path(app_data_root, relative);
+    candidate.is_file().then_some(candidate)
+}
+
+/// Read the roaming application data root from `%APPDATA%`.
+#[cfg(not(unix))]
+fn app_data_root() -> Result<PathBuf, ConfigLocationError> {
+    std::env::var_os("APPDATA")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or(ConfigLocationError::AppDataUnset)
+}
+
+/// Locate a configuration file by its path relative to Acton's configuration
+/// directory.
+///
+/// Returns `Ok(None)` when the search succeeded but no such file exists, and
+/// `Err` when the platform's configuration directory could not be determined.
+#[cfg(unix)]
+pub fn find_config_file(relative: &Path) -> Result<Option<PathBuf>, ConfigLocationError> {
+    let dirs = xdg::BaseDirectories::with_prefix(PREFIX)
+        .map_err(|e| ConfigLocationError::BaseDirectories(e.to_string()))?;
+    Ok(dirs.find_config_file(relative))
+}
+
+/// Locate a configuration file by its path relative to Acton's configuration
+/// directory.
+///
+/// Returns `Ok(None)` when the search succeeded but no such file exists, and
+/// `Err` when the platform's configuration directory could not be determined.
+#[cfg(not(unix))]
+pub fn find_config_file(relative: &Path) -> Result<Option<PathBuf>, ConfigLocationError> {
+    let root = app_data_root()?;
+    Ok(find_in_app_data(&root, relative))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn app_data_path_inserts_the_acton_prefix() {
+        let path = app_data_config_path(Path::new("/roaming"), Path::new("config.toml"));
+
+        assert_eq!(path, Path::new("/roaming/acton/config.toml"));
+    }
+
+    #[test]
+    fn app_data_path_preserves_a_nested_relative_path() {
+        let path = app_data_config_path(Path::new("/roaming"), &Path::new("myapp").join("ipc.toml"));
+
+        assert_eq!(path, Path::new("/roaming/acton/myapp/ipc.toml"));
+    }
+
+    #[test]
+    fn app_data_lookup_finds_an_existing_file() {
+        let root = TempDir::new().expect("temp dir");
+        let dir = root.path().join("acton");
+        fs::create_dir_all(&dir).expect("create acton dir");
+        fs::write(dir.join("config.toml"), "").expect("write config");
+
+        let found = find_in_app_data(root.path(), Path::new("config.toml"));
+
+        assert_eq!(found, Some(dir.join("config.toml")));
+    }
+
+    #[test]
+    fn app_data_lookup_reports_a_missing_file_as_none() {
+        let root = TempDir::new().expect("temp dir");
+
+        let found = find_in_app_data(root.path(), Path::new("config.toml"));
+
+        assert_eq!(found, None);
+    }
+
+    #[test]
+    fn app_data_lookup_rejects_a_directory_at_the_config_path() {
+        let root = TempDir::new().expect("temp dir");
+        fs::create_dir_all(root.path().join("acton").join("config.toml")).expect("create dir");
+
+        let found = find_in_app_data(root.path(), Path::new("config.toml"));
+
+        assert_eq!(
+            found, None,
+            "a directory named config.toml is not a configuration file"
+        );
+    }
+
+    /// Pins the `acton` prefix on the shipped Unix path, which the `app_data_*`
+    /// tests cannot reach. A typo in [`PREFIX`] would leave every Unix user's
+    /// configuration silently unread, and no other test in the crate asserts on
+    /// the located path.
+    ///
+    /// The written file is empty so that a sibling test initialising the global
+    /// `CONFIG` during the window still observes defaults; the environment is
+    /// restored before returning.
+    #[cfg(unix)]
+    #[test]
+    fn unix_lookup_finds_a_file_under_xdg_config_home() {
+        let root = TempDir::new().expect("temp dir");
+        let dir = root.path().join("acton");
+        fs::create_dir_all(&dir).expect("create acton dir");
+        fs::write(dir.join("config.toml"), "").expect("write config");
+
+        let previous = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", root.path());
+        let found = find_config_file(Path::new("config.toml"));
+        match previous {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+
+        assert_eq!(found, Ok(Some(dir.join("config.toml"))));
+    }
+
+    #[test]
+    fn app_data_unset_names_the_variable_to_set() {
+        let rendered = ConfigLocationError::AppDataUnset.to_string();
+
+        assert!(
+            rendered.contains("APPDATA"),
+            "message should name the variable, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn base_directories_error_carries_the_underlying_cause() {
+        let rendered =
+            ConfigLocationError::BaseDirectories("HOME is not set".to_string()).to_string();
+
+        assert!(
+            rendered.contains("HOME is not set"),
+            "message should carry the cause, got: {rendered}"
+        );
+    }
+}

--- a/acton-reactive/src/common/ipc/config.rs
+++ b/acton-reactive/src/common/ipc/config.rs
@@ -302,17 +302,23 @@ impl IpcConfig {
     /// If neither exists, the default configuration is returned.
     #[must_use]
     pub fn load() -> Self {
-        let xdg_dirs = match xdg::BaseDirectories::with_prefix("acton") {
-            Ok(dirs) => dirs,
+        let app_name = Self::default_app_name();
+
+        let located = crate::common::config_paths::find_config_file(
+            &PathBuf::from(&app_name).join(CONFIG_FILE_NAME),
+        )
+        .and_then(|per_app| {
+            crate::common::config_paths::find_config_file(Path::new(CONFIG_FILE_NAME))
+                .map(|shared| (per_app, shared))
+        });
+
+        let (per_app, shared) = match located {
+            Ok(paths) => paths,
             Err(e) => {
-                warn!("Failed to initialize XDG directories for IPC config: {}", e);
+                warn!("Failed to locate the configuration directory for IPC config: {e}");
                 return Self::default();
             }
         };
-
-        let app_name = Self::default_app_name();
-        let per_app = xdg_dirs.find_config_file(PathBuf::from(&app_name).join(CONFIG_FILE_NAME));
-        let shared = xdg_dirs.find_config_file(CONFIG_FILE_NAME);
 
         resolve_config_path(per_app, shared).map_or_else(
             || {

--- a/acton-reactive/src/common/mod.rs
+++ b/acton-reactive/src/common/mod.rs
@@ -81,6 +81,9 @@ mod actor_runtime;
 mod broker;
 /// Defines the configuration system for the Acton framework.
 pub mod config;
+/// Locates configuration files on the host platform (XDG on Unix, `%APPDATA%`
+/// elsewhere).
+mod config_paths;
 
 /// IPC (Inter-Process Communication) support for external process messaging.
 ///

--- a/acton-reactive/src/lib.rs
+++ b/acton-reactive/src/lib.rs
@@ -52,6 +52,17 @@
 //! }
 //! ```
 
+// The `ipc` feature is built on Unix domain sockets and has no equivalent on other
+// targets. Refusing here gives one legible message instead of a cascade of
+// unresolved-import errors from the transport layer.
+#[cfg(all(feature = "ipc", not(unix)))]
+compile_error!(
+    "the `ipc` feature of acton-reactive requires a Unix target: it is built on Unix domain \
+     sockets, which this target does not provide. Disable the `ipc` feature (and \
+     `ipc-messagepack`, which enables it) for this target, for example with \
+     `default-features = false` or a `[target.'cfg(unix)'.dependencies]` entry."
+);
+
 /// Internal utilities and structures used throughout the Acton framework.
 pub(crate) mod common;
 


### PR DESCRIPTION
Closes #17

## What

- `xdg` moves to `[target.'cfg(unix)'.dependencies]` — the crate's API is entirely `cfg(unix)`-gated upstream, so non-Unix builds no longer carry an unusable dependency.
- Configuration discovery moves into a private `common::config_paths` module that states the platform rule once: the XDG search path under the `acton` prefix on Unix (unchanged, including `$XDG_CONFIG_HOME` and `$XDG_CONFIG_DIRS`), `%APPDATA%\acton\<file>` everywhere else. `ActonConfig::load` and `IpcConfig::load` both delegate to it.
- "Could not determine where to search" is now distinguished from "searched, found nothing" and logged as an error instead of "using defaults".
- The `ipc` feature is built on Unix domain sockets; enabling it off Unix now fails with a single `compile_error!` naming the fix instead of a wall of unresolved-import errors.
- CI gains a `windows-latest` job (default-features build + test, no-default-features check).

## Verification

- clippy `-D warnings` clean: default, `--no-default-features`, `--features ipc`, `--all-features`
- `cargo nextest run`: 465 / 652 / 466 passed across default, `ipc-messagepack`, and no-default-features gates
- `cargo check` clean for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`; `--features ipc` on Windows produces exactly the intended `compile_error!`
- The non-Unix lookup takes its root as a parameter so the `%APPDATA%` layout rule is unit-tested on the Linux host; only the three-line env read is platform-exclusive

Version: 9.2.0 (workspace bump + changelog included).